### PR TITLE
Add macOS OpenSSL build

### DIFF
--- a/source/server/Makefile
+++ b/source/server/Makefile
@@ -1,7 +1,15 @@
-CC=gcc
-RELCFLAGS = -g
+UNAME := $(shell uname)
 
-LIBS = -lpthread -lm -ldl -lssl -lcrypto
+# macOS (Homebrew OpenSSL)
+ifeq ($(UNAME), Darwin)
+    RELCFLAGS = -g -I/opt/homebrew/opt/openssl@3/include
+    LIBS = -lpthread -lm -ldl -L/opt/homebrew/opt/openssl@3/lib -lssl -lcrypto
+else
+    RELCFLAGS = -g
+    LIBS = -lpthread -lm -ldl -lssl -lcrypto
+endif
+
+CC=gcc
 
 SRCS = main.c onem2m.c cJSON.c httpd.c dbmanager.c jsonparser.c mqttClient.c logger.c util.c filterCriteria.c coap.c rtManager.c
 

--- a/source/server/httpd.c
+++ b/source/server/httpd.c
@@ -284,7 +284,8 @@ void handle_http_request(HTTPRequest *req, int slotno)
     }
     if ((header = search_header(req->headers, "x-m2m-rsc")))
     {
-        o2pt->rsc = strdup(header);
+        // httpd.c:287:19: error: incompatible pointer to integer conversion assigning to 'int' from 'char *' [-Wint-conversion]
+        o2pt->rsc = atoi(header);
     }
 
     if ((header = search_header(req->headers, "x-m2m-rvi")))


### PR DESCRIPTION
안녕하세요 지능IoT플랫폼을 수강하는 학생입니다.

강의에서 tinyIoT가 macOS환경에서도 지원된다고 해서 빌드하려고 했으나

httpd.c:287:19: error: incompatible pointer to integer conversion assigning to 'int' from 'char *' [-Wint-conversion]
  287 |         o2pt->rsc = strdup(header);
      |                   ^ ~~~~~~~~~~~~~~
위와같은 에러가 발생하여 원인을 찾아보니
gcc와 clang의 타입체크기준이 다른것이 원인인것 같습니다.

그리고 OpenSSL을 잡아주지못해 macOS환경에서 HomeBrew OpenSSL@3환경변수를 추가했습니다.

수정후 macOS와 우분투환경에서 빌드와 실행 확인했습니다. 감사합니다.
